### PR TITLE
Add slicing

### DIFF
--- a/notebooks/examples/08_slicing.ipynb
+++ b/notebooks/examples/08_slicing.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Slicing\n",
+    "\n",
+    "Users coming from Python, and in particular NumPy, are familiar and used to powerful slicing operations. I tried to mirror that behavior to some extent and adopt in imklib as much as possible. As of now, only basic slicing is supported. Unfortunately, the very concise Python syntax for slicing, i.e.\n",
+    "```python\n",
+    "start:stop:step\n",
+    "```\n",
+    "where any of `start`, `stop`, `step` can be omitted, cannot be translated to Kotlin verbatim. Instead, I introduced a `Slicing` interface that can be either an `Ellipsis` (equivalent to `...` in Python) or a `Slice` (equivalent to `slice` in Python). For brevity, I introduced the following convenience functions with Python equivalent in comments (all functions are overloaded for combinations of `Long`/`Int` but only the `Long` overloads are presented, for brevity):\n",
+    "```Kotlin\n",
+    "infix fun Long.sl(stop: Long): Slice   // this:stop\n",
+    "infix fun Slice.st(step: Long): Slice  // slice.start:slice.stop:step\n",
+    "val Long.start: Slice                  // this:\n",
+    "val Long.stop: Slice                   // :this\n",
+    "val Long.step: Slice                   // ::this\n",
+    "```\n",
+    "The `Ellipsis` has a single instance that can be accessed via `_el` (name may change in the future)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// set up dependencies\n",
+    "// use local maven repository; not yet deployed to remote maven repositories.\n",
+    "@file:Repository(\"*mavenLocal\")\n",
+    "@file:Repository(\"https://maven.scijava.org/content/groups/public\")\n",
+    "@file:Repository(\"https://jitpack.io\")\n",
+    "\n",
+    "// uncomment to search in your local maven repo\n",
+    "// requires installation into local maven repository (./gradlew build publishToMavenLocal)\n",
+    "@file:DependsOn(\"net.imglib2:imklib2:0.1.0-SNAPSHOT\")\n",
+    "\n",
+    "// uncomment to search in jitpack\n",
+    "// @file:DependsOn(\"com.github.saalfeldlab:imklib2:08e9ae3d9eed2672caef868d80ea5778273d0da9\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import net.imglib2.imklib.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Examples\n",
+    "\n",
+    "### 1D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ArrayImg [10]: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@de8efa: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@5b531123: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@2ec64482: [3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@753ad5e0: [0, 1, 2, 3, 4, 5, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@6a5cd601: [0, 3, 6, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@494d96f0: [9, 6, 3, 0]\n",
+      "net.imglib2.view.SubsampleIntervalView@62a61f3c: [1, 2, 3, 4, 5, 6, 7, 8]\n",
+      "net.imglib2.view.SubsampleIntervalView@301976a8: [1, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@6f558842: [8, 3]\n"
+     ]
+    }
+   ],
+   "source": [
+    "val img = imklib.ints(10) { it }\n",
+    "println(img.flatStringRepresentation)\n",
+    "println(img[_el].flatStringRepresentation)\n",
+    "println(img[Slice()].flatStringRepresentation)\n",
+    "println(img[3.start].flatStringRepresentation)\n",
+    "println(img[7.stop].flatStringRepresentation)\n",
+    "println(img[3.step].flatStringRepresentation)\n",
+    "println(img[(-3).step].flatStringRepresentation)\n",
+    "println(img[1 sl 9].flatStringRepresentation)\n",
+    "println(img[1 sl 9 st 5].flatStringRepresentation)\n",
+    "println(img[1 sl 9 st -5].flatStringRepresentation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IntervalView [(0) -- (1) = 2]: [0, 1]\n",
+      "IntervalView [(0) -- (1) = 2]: [2, 3]\n",
+      "IntervalView [(0) -- (1) = 2]: [4, 5]\n",
+      "\n",
+      "IntervalView [(0) -- (1) = 2]: [1, 0]\n",
+      "IntervalView [(0) -- (1) = 2]: [3, 2]\n",
+      "IntervalView [(0) -- (1) = 2]: [5, 4]\n",
+      "\n",
+      "IntervalView [(0) -- (1) = 2]: [4, 5]\n",
+      "IntervalView [(0) -- (1) = 2]: [2, 3]\n",
+      "IntervalView [(0) -- (1) = 2]: [0, 1]\n",
+      "\n",
+      "IntervalView [(0) -- (1) = 2]: [5, 4]\n",
+      "IntervalView [(0) -- (1) = 2]: [3, 2]\n",
+      "IntervalView [(0) -- (1) = 2]: [1, 0]\n",
+      "\n",
+      "IntervalView [(0) -- (1) = 2]: [5, 4]\n",
+      "IntervalView [(0) -- (1) = 2]: [3, 2]\n",
+      "\n",
+      "IntervalView [(0) -- (1) = 2]: [5, 4]\n",
+      "IntervalView [(0) -- (1) = 2]: [1, 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "val img = imklib.ints(2, 3) { it }\n",
+    "img.hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "img[(-1).step].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "img[_el, (-1).step].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "img[(-1).step, (-1).step].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "img[(-1).step, 1 sl 3 st -1].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "img[(-1).step, 3.stop st -2].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Kotlin",
+   "language": "kotlin",
+   "name": "kotlin"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-kotlin",
+   "file_extension": ".kt",
+   "mimetype": "text/x-kotlin",
+   "name": "kotlin",
+   "pygments_lexer": "kotlin",
+   "version": "1.4.20-dev-2342"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/examples/08_slicing.ipynb
+++ b/notebooks/examples/08_slicing.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Slicing\n",
     "\n",
-    "Users coming from Python, and in particular NumPy, are familiar and used to powerful slicing operations. I tried to mirror that behavior to some extent and adopt in imklib as much as possible. As of now, only basic slicing is supported. Unfortunately, the very concise Python syntax for slicing, i.e.\n",
+    "Users coming from Python, and in particular NumPy, are familiar and used to powerful slicing operations. I tried to mirror that behavior for `RandomAccessibleInterval` to some extent and adopt in imklib as much as possible. As of now, only basic slicing is supported. Unfortunately, the very concise Python syntax for slicing, i.e.\n",
     "```python\n",
     "start:stop:step\n",
     "```\n",
@@ -18,7 +18,9 @@
     "val Long.stop: Slice                   // :this\n",
     "val Long.step: Slice                   // ::this\n",
     "```\n",
-    "The `Ellipsis` has a single instance that can be accessed via `_el` (name may change in the future)."
+    "The `Ellipsis` has a single instance that can be accessed via `_el` (name may change in the future).\n",
+    "\n",
+    "**Note**: `min` and `max` of a `RandomAccessibleInterval` are not considered and `RandomAccessibleInterval.isZeroMin` is enforced."
    ]
   },
   {
@@ -69,15 +71,20 @@
      "output_type": "stream",
      "text": [
       "ArrayImg [10]: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@de8efa: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@5b531123: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@2ec64482: [3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@753ad5e0: [0, 1, 2, 3, 4, 5, 6]\n",
-      "net.imglib2.view.SubsampleIntervalView@6a5cd601: [0, 3, 6, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@494d96f0: [9, 6, 3, 0]\n",
-      "net.imglib2.view.SubsampleIntervalView@62a61f3c: [1, 2, 3, 4, 5, 6, 7, 8]\n",
-      "net.imglib2.view.SubsampleIntervalView@301976a8: [1, 6]\n",
-      "net.imglib2.view.SubsampleIntervalView@6f558842: [8, 3]\n"
+      "net.imglib2.view.SubsampleIntervalView@145f37c4: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@1ac5db01: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@610c68f5: [3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@e31e8cb: [3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@1fe05ad6: [0, 1, 2, 3, 4, 5, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@668edc17: [0, 3, 6, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@3cce7415: [9, 6, 3, 0]\n",
+      "net.imglib2.view.SubsampleIntervalView@7abc9db: [1, 2, 3, 4, 5, 6, 7, 8]\n",
+      "net.imglib2.view.SubsampleIntervalView@3cf8ae5d: [1, 2, 3, 4, 5, 6, 7, 8]\n",
+      "net.imglib2.view.SubsampleIntervalView@67c655c6: [1, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@7ebd36ea: [1, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@2781cdf7: [8, 3]\n",
+      "net.imglib2.view.SubsampleIntervalView@5e72151c: [8, 3]\n",
+      "net.imglib2.view.SubsampleIntervalView@b4f0371: []\n"
      ]
     }
    ],
@@ -87,12 +94,17 @@
     "println(img[_el].flatStringRepresentation)\n",
     "println(img[Slice()].flatStringRepresentation)\n",
     "println(img[3.start].flatStringRepresentation)\n",
+    "println(img.translate(1345315L)[3.start].flatStringRepresentation)\n",
     "println(img[7.stop].flatStringRepresentation)\n",
     "println(img[3.step].flatStringRepresentation)\n",
     "println(img[(-3).step].flatStringRepresentation)\n",
     "println(img[1 sl 9].flatStringRepresentation)\n",
+    "println(img[1 sl -1].flatStringRepresentation)\n",
     "println(img[1 sl 9 st 5].flatStringRepresentation)\n",
-    "println(img[1 sl 9 st -5].flatStringRepresentation)"
+    "println(img[1 sl -1 st 5].flatStringRepresentation)\n",
+    "println(img[1 sl 9 st -5].flatStringRepresentation)\n",
+    "println(img[1 sl -1 st -5].flatStringRepresentation)\n",
+    "println(img[1 sl 1].flatStringRepresentation)"
    ]
   },
   {

--- a/src/main/kotlin/IntervalExtensions.kt
+++ b/src/main/kotlin/IntervalExtensions.kt
@@ -111,3 +111,5 @@ fun RealInterval.transformBoundingBox(transformation: AffineGet): RealInterval {
 }
 
 val RealInterval.smallestsContaining get() = Intervals.smallestContainingInterval(this)
+
+val Interval.isEmpty: Boolean get() = Intervals.isEmpty(this)

--- a/src/main/kotlin/IntervalExtensions.kt
+++ b/src/main/kotlin/IntervalExtensions.kt
@@ -61,6 +61,8 @@ val Interval.maxAsInts: IntArray get() = IntArray(numDimensions()) { max(it).toI
 val Interval.minAsPoint: Point get() = minAsPoint()
 val Interval.maxAsPoint: Point get() = maxAsPoint()
 
+val Interval.numElements: Long get() = Intervals.numElements(this)
+
 infix fun Interval.intersect(that: Interval) = Intervals.intersect(this, that)
 infix fun Interval.union(that: Interval) = Intervals.union(this, that)
 operator fun Interval.contains(that: Interval) = Intervals.contains(this, that)

--- a/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
+++ b/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
@@ -88,7 +88,7 @@ fun <T> RAI<T>.extendMirrorSingle() = Views.extendMirrorSingle(this)
 fun <T> RAI<T>.extendPeriodic() = Views.extendPeriodic(this)
 fun <T: RealType<T>> RAI<T>.extendRandom(min: Double, max: Double) = Views.extendRandom(this, min, max)
 
-val <T> RAI<T>.flatStringRepresentation get() = "$this: ${flatIterable.joinToString(" ,", "[", "]")}"
+val <T> RAI<T>.flatStringRepresentation get() = "$this: ${flatIterable.joinToString(", ", "[", "]")}"
 
 val RAI<*>.isZeroMin get() = Views.isZeroMin(this)
 val <T> RAI<T>.zeroMin get() = if (isZeroMin) this else Views.zeroMin(this)

--- a/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
+++ b/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
@@ -30,6 +30,7 @@ import bdv.util.BdvOptions
 import bdv.util.BdvStackSource
 import bdv.util.volatiles.VolatileViews
 import gnu.trove.list.array.TLongArrayList
+import net.imglib2.Dimensions
 import net.imglib2.Interval
 import net.imglib2.Localizable
 import net.imglib2.Point
@@ -53,6 +54,7 @@ import net.imglib2.type.operators.Sub
 import net.imglib2.util.ConstantUtils
 import net.imglib2.util.Util
 import net.imglib2.view.Views
+import kotlin.math.abs
 import kotlin.math.absoluteValue
 import net.imglib2.RandomAccessible as RA
 import net.imglib2.RandomAccessibleInterval as RAI
@@ -210,20 +212,51 @@ fun RAI<BooleanType<*>>.any() = iterable.cursor().let { c ->
     false
 }
 
+/**
+ * Add slicing access to [RAI] similar to Python. Slices are used to create a sub-interval view that is contained in the
+ * original [RAI]. Note that only the dimensions of a [RAI] are considered, but not its min and max. The start and stop
+ * values of a [Slice] are with respect to the dimensions of a [RAI], i.e. between `0` and `dimension`, while min may be
+ * non-zero, and max at `min + dimension - 1`. In other words, [RAI.isZeroMin] is ensured if necessary. Example:
+ * ```kotlin
+ * val data = imklib.ints(10) { it }
+ * // all elements
+ * val data = data[Slice()]
+ * // all elements
+ * val data = data[_el]
+ * // every other element
+ * data[2.step]
+ * // data in reversed order
+ * data[(-1).step]
+ * // all elements starting at index 3
+ * data[3.start]
+ * // all elements before index 7
+ * data[7.stop]
+ * // every other element between 3 (inclusive) and 7 (exclusive)
+ * data[3 sl 7 st 2]
+ * // every other element between 7 (exclusive) and 3 (inclusive)
+ * data[3 sl 7 st -2]
+ * ```
+ *
+ * In the case of multiple dimensions, slices need not be provided for all dimensions. If there are fewer slices than
+ * dimensions, multiple `Slice()` will be appended as needed. To omit `Slice()` at the start or in the middle, use the
+ * Ellipsis object `_el`. Only one ellipsis can be passed (more ellipses would be ambiguous). Examples:
+ * ```kotlin
+ * data = imklib.ints(3, 4) { it }
+ * // all data
+ * data[_el]
+ * // every other column
+ * data[2.step]
+ * // every other row
+ * data[Slice(), 2.step]
+ * // every other row
+ * data[_el, 2.step]
+ * // every other row from index 4 (exclusive) to index 1 (inclusive)
+ * data[_el, 1.start st -2]
+ * ```
+ */
 operator fun <T> RAI<T>.get(vararg slicing: Slicing): RAI<T> {
-    require(slicing.size <= nDim) { "Number of slices has to be smalller or equal to number of dimensions but got: ${slicing.size} > $nDim. Slicing: ${slicing.toList()}" }
-    require(slicing.filter { it == _el }.size <= 1) { "Cannot use more than 1 Ellipsis object. Slicing: ${slicing.toList()}" }
-    return when {
-        slicing.any { it == _el } -> {
-            val index = slicing.indexOf(_el)
-            val before = slicing.toList().subList(0, index)
-            val after = slicing.toList().subList(index + 1, slicing.size)
-            get(*(before + List(nDim - before.size - after.size) { Slice() } + after).toTypedArray())
-        }
-        slicing.size < nDim -> get(*(slicing.toList() + List(nDim - slicing.size) { Slice() }).toTypedArray())
-        slicing.all { it is Slice } -> this.applyCompleteSlicing(slicing.map { it as Slice })
-        else -> error("blub")
-    }
+    val nonNullSlices = sanitizeSlicing(slicing.toList()).mapIndexed { d, slice -> sanitizeSlice(slice, dimension(d)) }
+    return applyCompleteSlicing(nonNullSlices)
 }
 
 public fun RAI<out IntegerType<*>>.toIntArray(useFlatIterationOrder: Boolean = true) =
@@ -235,8 +268,49 @@ public fun RAI<RealType<*>>.toFloatArray(flatIterationOrder: Boolean = true) =
 public fun RAI<RealType<*>>.toDoubleArray(flatIterationOrder: Boolean = true) =
     DoubleArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealDouble() } }
 
-private fun <T> RAI<T>.applyCompleteSlicing(slicing: List<Slice>): RAI<T> {
-    val restricted = this[slicing.interval(this)] as RAI<T>
-    val inverted = (0 until nDim).fold(restricted) { acc, d -> if (slicing[d].step?.let { it < 0 } == true) acc.invertAxis(d) else acc }
-    return inverted.zeroMin.subsample(*slicing.map { it.step?.absoluteValue ?: 1 }.toLongArray())
+private fun Dimensions.sanitizeSlicing(slicing: List<Slicing>): List<Slice> {
+    require(slicing.size <= nDim) { "Number of slices has to be smalller or equal to number of dimensions but got: ${slicing.size} > $nDim. Slicing: ${slicing.toList()}" }
+    require(slicing.count { it == _el } <= 1) { "Cannot use more than 1 Ellipsis object. Slicing: ${slicing.toList()}" }
+    return when {
+        slicing.any { it == _el } -> {
+            val index = slicing.indexOf(_el)
+            val before = slicing.toList().subList(0, index)
+            val after = slicing.toList().subList(index + 1, slicing.size)
+            sanitizeSlicing(before + List(nDim - before.size - after.size) { Slice() } + after)
+        }
+        slicing.size < nDim -> sanitizeSlicing(slicing + listOf(_el)) // Using listOf(_el) here only works because the case slicing.any { it == _el } is executed first
+        slicing.all { it is Slice } -> slicing.map { it as Slice }
+        else -> error("Invalid slicing: $slicing")
+    }
 }
+
+private fun sanitizeSlice(slice: Slice, dimension: Long): SanitizedSlice =  when {
+    slice.start === null -> sanitizeSlice(slice.withStart(0L), dimension)
+    slice.stop === null -> sanitizeSlice(slice.withStop(dimension), dimension)
+    slice.step === null -> sanitizeSlice(slice.withStep(1L), dimension)
+    slice.start < 0 -> sanitizeSlice(slice.withStart(dimension - abs(slice.start.rem(dimension))), dimension)
+    slice.stop < 0 -> sanitizeSlice(slice.withStop(dimension - abs(slice.stop.rem(dimension))), dimension)
+    slice.start > dimension -> sanitizeSlice(slice.withStart(dimension), dimension)
+    slice.stop > dimension -> sanitizeSlice(slice.withStop(dimension), dimension)
+    slice.start > slice.stop -> sanitizeSlice(slice.withStop(slice.start), dimension)
+    else -> SanitizedSlice(start = slice.start, stop = slice.stop, step = slice.step)
+}
+
+private fun <T> RAI<T>.applyCompleteSlicing(slicing: List<SanitizedSlice>): RAI<T> = when {
+    isZeroMin -> {
+        val restricted = this[slicing.interval].zeroMin as RAI<T>
+        val inverted = (0 until nDim).fold(restricted) { acc, d -> if (slicing[d].step.let { it < 0 } == true) acc.invertAxis(d) else acc }
+        inverted.zeroMin.subsample(*slicing.map { it.step.absoluteValue }.toLongArray())
+    }
+    else -> zeroMin.applyCompleteSlicing(slicing)
+
+}
+
+private data class SanitizedSlice(val start: Long, val stop: Long, val step: Long) {
+    init {
+        require(start <= stop) {"start is larger than stop: $start > $stop"}
+        require(step != 0L) {"Invalid step=$step"}
+    }
+}
+
+private val List<SanitizedSlice>.interval get() = (map { it.start } + map { it.stop - 1 }).toLongArray().intervalMinMax

--- a/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
+++ b/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
@@ -28,7 +28,6 @@ package net.imglib2.imklib
 import bdv.util.BdvFunctions
 import bdv.util.BdvOptions
 import bdv.util.BdvStackSource
-import bdv.util.volatiles.VolatileRandomAccessibleIntervalView
 import bdv.util.volatiles.VolatileViews
 import gnu.trove.list.array.TLongArrayList
 import net.imglib2.Interval
@@ -54,6 +53,7 @@ import net.imglib2.type.operators.Sub
 import net.imglib2.util.ConstantUtils
 import net.imglib2.util.Util
 import net.imglib2.view.Views
+import kotlin.math.absoluteValue
 import net.imglib2.RandomAccessible as RA
 import net.imglib2.RandomAccessibleInterval as RAI
 
@@ -74,6 +74,7 @@ val <T: Type<T>> RAI<T>.type get() = this[minAsPoint()].createVariable()
 
 val <T> RAI<T>.iterable get() = Views.iterable(this)
 val <T> RAI<T>.flatIterable get() = Views.flatIterable(this)
+fun <T> RAI<T>.iterable(useFlatIterationOrder: Boolean) = if (useFlatIterationOrder) flatIterable else iterable
 
 fun <T: Type<T>> RAI<T>.extendValue(extension: T) = Views.extendValue(this, extension)
 fun <T: RealType<T>> RAI<T>.extendValue(extension: Float) = Views.extendValue(this, extension)
@@ -89,8 +90,11 @@ fun <T: RealType<T>> RAI<T>.extendRandom(min: Double, max: Double) = Views.exten
 
 val <T> RAI<T>.flatStringRepresentation get() = "$this: ${flatIterable.joinToString(" ,", "[", "]")}"
 
-val <T> RAI<T>.isZeroMin get() = Views.isZeroMin(this)
+val RAI<*>.isZeroMin get() = Views.isZeroMin(this)
 val <T> RAI<T>.zeroMin get() = if (isZeroMin) this else Views.zeroMin(this)
+fun <T> RAI<T>.subsample(step: Long) = Views.subsample(this, step)
+fun <T> RAI<T>.subsample(vararg steps: Long): RAI<T> = Views.subsample(this, *steps)
+fun <T> RAI<T>.invertAxis(d: Int): RAI<T> = Views.invertAxis(this, d)
 
 fun <T: NativeType<T>> RAI<T>.materialize(factory: ImgFactory<T> = Util.getSuitableImgFactory(this, type)) = factory
         .create(this)
@@ -189,3 +193,50 @@ fun <T: IntegerType<T>, I: IntegerType<I>> RAI<T>.mean(d: Int, i: I) = sum(d, i)
 fun <T: RealType<T>, R: RealType<R>> RAI<T>.mean(d: Int, r: R) = sum(d, r) / (max(d) - min(d) + 1).toDouble()
 @JvmName("meanInt") fun <T: IntegerType<T>> RAI<T>.mean(d: Int) = mean(d, imklib.types.long)
 @JvmName("meanReal") fun <T: RealType<T>> RAI<T>.mean(d: Int) = mean(d, imklib.types.double)
+
+fun RAI<out BooleanType<*>>.all() = iterable.cursor().let { c ->
+    while (c.hasNext()) {
+        if (!c.next().get())
+            return@let false
+    }
+    true
+}
+
+fun RAI<BooleanType<*>>.any() = iterable.cursor().let { c ->
+    while (c.hasNext()) {
+        if (c.next().get())
+            return@let true
+    }
+    false
+}
+
+operator fun <T> RAI<T>.get(vararg slicing: Slicing): RAI<T> {
+    require(slicing.size <= nDim) { "Number of slices has to be smalller or equal to number of dimensions but got: ${slicing.size} > $nDim. Slicing: ${slicing.toList()}" }
+    require(slicing.filter { it == _el }.size <= 1) { "Cannot use more than 1 Ellipsis object. Slicing: ${slicing.toList()}" }
+    return when {
+        slicing.any { it == _el } -> {
+            val index = slicing.indexOf(_el)
+            val before = slicing.toList().subList(0, index)
+            val after = slicing.toList().subList(index + 1, slicing.size)
+            get(*(before + List(nDim - before.size - after.size) { Slice() } + after).toTypedArray())
+        }
+        slicing.size < nDim -> get(*(slicing.toList() + List(nDim - slicing.size) { Slice() }).toTypedArray())
+        slicing.all { it is Slice } -> this.applyCompleteSlicing(slicing.map { it as Slice })
+        else -> error("blub")
+    }
+}
+
+public fun RAI<out IntegerType<*>>.toIntArray(useFlatIterationOrder: Boolean = true) =
+    IntArray(numElements.toInt()).also { a -> iterable(useFlatIterationOrder).forEachIndexed { i, type -> a[i] = type.getInteger() } }
+public fun RAI<out IntegerType<*>>.toLongArray(flatIterationOrder: Boolean = true) =
+    LongArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getIntegerLong() } }
+public fun RAI<RealType<*>>.toFloatArray(flatIterationOrder: Boolean = true) =
+    FloatArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealFloat() } }
+public fun RAI<RealType<*>>.toDoubleArray(flatIterationOrder: Boolean = true) =
+    DoubleArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealDouble() } }
+
+private fun <T> RAI<T>.applyCompleteSlicing(slicing: List<Slice>): RAI<T> {
+    val restricted = this[slicing.interval(this)] as RAI<T>
+    val inverted = (0 until nDim).fold(restricted) { acc, d -> if (slicing[d].step?.let { it < 0 } == true) acc.invertAxis(d) else acc }
+    return inverted.zeroMin.subsample(*slicing.map { it.step?.absoluteValue ?: 1 }.toLongArray())
+}

--- a/src/main/kotlin/Slice.kt
+++ b/src/main/kotlin/Slice.kt
@@ -37,9 +37,12 @@ data class Slice(
         val stop: Long? = null,
         val step: Long? = null): Slicing {
     init {
-        require(start === null || stop === null || stop > start)
         require(step === null || step != 0L)
     }
+
+    fun withStart(start: Long?) = Slice(start = start, stop = stop, step = step)
+    fun withStop(stop: Long?) = Slice(start = start, stop = stop, step = step)
+    fun withStep(step: Long?) = Slice(start = start, stop = stop, step = step)
 }
 
 class Ellipsis private constructor() : Slicing {
@@ -63,10 +66,3 @@ val Long.step get() = Slice(step=this)
 
 infix fun Slice.st(step: Int) = st(step.toLong())
 infix fun Slice.st(step: Long) = Slice(start=start, stop=stop, step=step)
-
-fun List<Slice>.interval(interval: Interval): Interval {
-    require(size == interval.nDim) {"Inconsistent size: size != interval.nDim: $size != ${interval.nDim}"}
-    val min = LongArray(size) { i -> this[i].start?.let { min(max(it, interval.min(i)), interval.max(i)) } ?: interval.min(i) }
-    val max = LongArray(size) { i -> this[i].stop?.let { min(max(it - 1, interval.min(i)), interval.max(i)) } ?: interval.max(i) }
-    return FinalInterval(min, max)
-}

--- a/src/main/kotlin/Slice.kt
+++ b/src/main/kotlin/Slice.kt
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2020, Saalfeld Lab, HHMI Janelia
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.imglib2.imklib
+
+import net.imglib2.FinalInterval
+import net.imglib2.Interval
+import kotlin.math.max
+import kotlin.math.min
+
+interface Slicing
+
+data class Slice(
+        val start: Long? = null,
+        val stop: Long? = null,
+        val step: Long? = null): Slicing {
+    init {
+        require(start === null || stop === null || stop > start)
+        require(step === null || step != 0L)
+    }
+}
+
+class Ellipsis private constructor() : Slicing {
+    companion object {
+        val instance = Ellipsis()
+    }
+}
+val _el = Ellipsis.instance
+
+infix fun Int.sl(stop: Int) = toLong() sl stop
+infix fun Int.sl(stop: Long) = toLong() sl stop
+infix fun Long.sl(stop: Int) = sl(stop.toLong())
+infix fun Long.sl(stop: Long) = Slice(start=this, stop=stop)
+
+val Int.start get() = toLong().start
+val Int.stop get() = toLong().stop
+val Int.step get() = toLong().step
+val Long.start get() = Slice(start=this)
+val Long.stop get() = Slice(stop=this)
+val Long.step get() = Slice(step=this)
+
+infix fun Slice.st(step: Int) = st(step.toLong())
+infix fun Slice.st(step: Long) = Slice(start=start, stop=stop, step=step)
+
+fun List<Slice>.interval(interval: Interval): Interval {
+    require(size == interval.nDim) {"Inconsistent size: size != interval.nDim: $size != ${interval.nDim}"}
+    val min = LongArray(size) { i -> this[i].start?.let { min(max(it, interval.min(i)), interval.max(i)) } ?: interval.min(i) }
+    val max = LongArray(size) { i -> this[i].stop?.let { min(max(it - 1, interval.min(i)), interval.max(i)) } ?: interval.max(i) }
+    return FinalInterval(min, max)
+}

--- a/src/test/kotlin/TestLogicalExtensions.kt
+++ b/src/test/kotlin/TestLogicalExtensions.kt
@@ -27,8 +27,6 @@ package net.imglib2.imklib
 
 import net.imglib2.Point
 import net.imglib2.type.logic.BoolType
-import net.imglib2.type.numeric.RealType
-import net.imglib2.type.numeric.integer.IntType
 import kotlin.test.Test
 import net.imglib2.RandomAccessible as RA
 import net.imglib2.RandomAccessibleInterval as RAI

--- a/src/test/kotlin/TestSlicing.kt
+++ b/src/test/kotlin/TestSlicing.kt
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2020, Saalfeld Lab, HHMI Janelia
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.imglib2.imklib
+
+import org.junit.Assert
+import kotlin.test.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestSlicing {
+
+    @Test fun `test 1D slicing same interval`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[_el]
+        Assert.assertArrayEquals(data.dimensionsAsLongArray(), sliced.dimensionsAsLongArray())
+        Assert.assertTrue((sliced eq data).all())
+    }
+
+    @Test fun `test 1D slicing invert axis`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[(-1).step]
+        Assert.assertArrayEquals(IntArray(10) { it }.reversedArray(), sliced.toIntArray())
+    }
+
+    @Test fun `test 1D slicing every third`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[3.step]
+        Assert.assertArrayEquals(intArrayOf(0, 3, 6, 9), sliced.toIntArray())
+    }
+
+    @Test fun `test 1D slicing every third invert axis`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[(-3).step]
+        Assert.assertArrayEquals(intArrayOf(9, 6, 3, 0), sliced.toIntArray())
+    }
+
+    @Test fun `test 1D slicing start at 3`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[3.start]
+        Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced.toIntArray())
+    }
+
+    @Test fun `test 1D slicing stop at 7`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[7.stop]
+        Assert.assertArrayEquals(IntArray(7) { it }, sliced.toIntArray())
+    }
+
+    @Test fun `test 1D slicing start=3 stop=7 step=3`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[3 sl 7 st 3]
+        Assert.assertArrayEquals(intArrayOf(3, 6), sliced.toIntArray())
+    }
+
+    @Test fun `test 1D slicing start=3 stop=7 step=-3`() {
+        val data = imklib.ints(10) { it }
+        val sliced = data[3 sl 7 st -3]
+        Assert.assertArrayEquals(intArrayOf(6, 3), sliced.toIntArray())
+    }
+
+    @Test fun `slice 3D`() {
+        val data = imklib.ints(2, 3, 4) { it }
+        val sliced1 = data[Slice(), _el, 3 sl 4]
+        val sliced2 = data[_el, 3 sl 4]
+        val expected = IntArray(6) { it + 18 }
+        Assert.assertArrayEquals(expected, sliced1.toIntArray())
+        Assert.assertArrayEquals(expected, sliced2.toIntArray())
+    }
+
+    @Test fun `slice 3D invert axis`() {
+        val data = imklib.ints(2, 3, 4) { it }
+        val sliced = data[(-1).step, (-1).step, 3 sl 4]
+        val expected = IntArray(6) { it + 18 }.reversedArray()
+        Assert.assertArrayEquals(expected, sliced.toIntArray())
+    }
+
+}

--- a/src/test/kotlin/TestSlicing.kt
+++ b/src/test/kotlin/TestSlicing.kt
@@ -59,26 +59,54 @@ class TestSlicing {
 
     @Test fun `test 1D slicing start at 3`() {
         val data = imklib.ints(10) { it }
-        val sliced = data[3.start]
-        Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced.toIntArray())
+        val sliced1 = data[3.start]
+        val sliced2 = data[(-7).start]
+        val sliced3 = data[(-17).start]
+        Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced1.toIntArray())
+        Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced2.toIntArray())
+        Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced3.toIntArray())
     }
 
     @Test fun `test 1D slicing stop at 7`() {
         val data = imklib.ints(10) { it }
-        val sliced = data[7.stop]
-        Assert.assertArrayEquals(IntArray(7) { it }, sliced.toIntArray())
+        val sliced1 = data[7.stop]
+        val sliced2 = data[(-3).stop]
+        val sliced3 = data[(-13).stop]
+        Assert.assertArrayEquals(IntArray(7) { it }, sliced1.toIntArray())
+        Assert.assertArrayEquals(IntArray(7) { it }, sliced2.toIntArray())
+        Assert.assertArrayEquals(IntArray(7) { it }, sliced3.toIntArray())
     }
 
     @Test fun `test 1D slicing start=3 stop=7 step=3`() {
         val data = imklib.ints(10) { it }
-        val sliced = data[3 sl 7 st 3]
-        Assert.assertArrayEquals(intArrayOf(3, 6), sliced.toIntArray())
+        val sliced1 = data[3 sl 7 st 3]
+        val sliced2 = data[3 sl -3 st 3]
+        val sliced3 = data[-7 sl -3 st 3]
+        Assert.assertArrayEquals(intArrayOf(3, 6), sliced1.toIntArray())
+        Assert.assertArrayEquals(intArrayOf(3, 6), sliced2.toIntArray())
+        Assert.assertArrayEquals(intArrayOf(3, 6), sliced3.toIntArray())
     }
 
     @Test fun `test 1D slicing start=3 stop=7 step=-3`() {
         val data = imklib.ints(10) { it }
-        val sliced = data[3 sl 7 st -3]
-        Assert.assertArrayEquals(intArrayOf(6, 3), sliced.toIntArray())
+        val sliced1 = data[3 sl 7 st -3]
+        val sliced2 = data[3 sl -3 st -3]
+        val sliced3 = data[-7 sl -3 st -3]
+        Assert.assertArrayEquals(intArrayOf(6, 3), sliced1.toIntArray())
+        Assert.assertArrayEquals(intArrayOf(6, 3), sliced2.toIntArray())
+        Assert.assertArrayEquals(intArrayOf(6, 3), sliced3.toIntArray())
+    }
+
+    @Test fun `test 1D slicing empty`() {
+        val data = imklib.ints(10) { it }
+        val sliced1 = data[10.start]
+        val sliced2 = data[0.stop]
+        val sliced3 = data[3 sl 2]
+        val sliced4 = data[7 sl -3]
+        Assert.assertTrue(sliced1.isEmpty)
+        Assert.assertTrue(sliced2.isEmpty)
+        Assert.assertTrue(sliced3.isEmpty)
+        Assert.assertTrue(sliced4.isEmpty)
     }
 
     @Test fun `slice 3D`() {
@@ -95,6 +123,16 @@ class TestSlicing {
         val sliced = data[(-1).step, (-1).step, 3 sl 4]
         val expected = IntArray(6) { it + 18 }.reversedArray()
         Assert.assertArrayEquals(expected, sliced.toIntArray())
+    }
+
+    @Test fun `test 3D slicing empty`() {
+        val data = imklib.ints(2, 3, 4) { it }
+        val sliced1 = data[0.stop]
+        val sliced2 = data[Slice(), 0.stop]
+        val sliced3 = data[_el, 0.stop]
+        Assert.assertTrue(sliced1.isEmpty)
+        Assert.assertTrue(sliced2.isEmpty)
+        Assert.assertTrue(sliced3.isEmpty)
     }
 
 }


### PR DESCRIPTION

WIP
 - [x] Examples in notebook
 - [x] Define behavior of `min/max` with non-unit/negative step, in particular if `min == 0`. Should the result always be `zeroMin`, similar to what numpy is doing? **Solution**: Always enforce zero min