### PR TITLE
Refine slicing

### DIFF
--- a/notebooks/examples/08_slicing.ipynb
+++ b/notebooks/examples/08_slicing.ipynb
@@ -17,6 +17,7 @@
     "val Long.start: Slice                  // this:\n",
     "val Long.stop: Slice                   // :this\n",
     "val Long.step: Slice                   // ::this\n",
+    "val Long.pos: Position                 // this (pin dim to index by scalar; reduces number of dims by 1)\n",
     "```\n",
     "The `Ellipsis` has a single instance that can be accessed via `_el` (name may change in the future).\n",
     "\n",
@@ -71,20 +72,20 @@
      "output_type": "stream",
      "text": [
       "ArrayImg [10]: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@145f37c4: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@1ac5db01: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@610c68f5: [3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@e31e8cb: [3, 4, 5, 6, 7, 8, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@1fe05ad6: [0, 1, 2, 3, 4, 5, 6]\n",
-      "net.imglib2.view.SubsampleIntervalView@668edc17: [0, 3, 6, 9]\n",
-      "net.imglib2.view.SubsampleIntervalView@3cce7415: [9, 6, 3, 0]\n",
-      "net.imglib2.view.SubsampleIntervalView@7abc9db: [1, 2, 3, 4, 5, 6, 7, 8]\n",
-      "net.imglib2.view.SubsampleIntervalView@3cf8ae5d: [1, 2, 3, 4, 5, 6, 7, 8]\n",
-      "net.imglib2.view.SubsampleIntervalView@67c655c6: [1, 6]\n",
-      "net.imglib2.view.SubsampleIntervalView@7ebd36ea: [1, 6]\n",
-      "net.imglib2.view.SubsampleIntervalView@2781cdf7: [8, 3]\n",
-      "net.imglib2.view.SubsampleIntervalView@5e72151c: [8, 3]\n",
-      "net.imglib2.view.SubsampleIntervalView@b4f0371: []\n"
+      "net.imglib2.view.SubsampleIntervalView@101388c2: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@62d34eed: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@94d95e: [3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@13e596de: [3, 4, 5, 6, 7, 8, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@4d46ba39: [0, 1, 2, 3, 4, 5, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@5e01bb04: [0, 3, 6, 9]\n",
+      "net.imglib2.view.SubsampleIntervalView@64685301: [9, 6, 3, 0]\n",
+      "net.imglib2.view.SubsampleIntervalView@2e1a7283: [1, 2, 3, 4, 5, 6, 7, 8]\n",
+      "net.imglib2.view.SubsampleIntervalView@512e50a3: [1, 2, 3, 4, 5, 6, 7, 8]\n",
+      "net.imglib2.view.SubsampleIntervalView@2f269651: [1, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@42c1b6a1: [1, 6]\n",
+      "net.imglib2.view.SubsampleIntervalView@3fb25a10: [8, 3]\n",
+      "net.imglib2.view.SubsampleIntervalView@1cbaae0d: [8, 3]\n",
+      "net.imglib2.view.SubsampleIntervalView@73527d5: []\n"
      ]
     }
    ],
@@ -92,7 +93,7 @@
     "val img = imklib.ints(10) { it }\n",
     "println(img.flatStringRepresentation)\n",
     "println(img[_el].flatStringRepresentation)\n",
-    "println(img[Slice()].flatStringRepresentation)\n",
+    "println(img[slice()].flatStringRepresentation)\n",
     "println(img[3.start].flatStringRepresentation)\n",
     "println(img.translate(1345315L)[3.start].flatStringRepresentation)\n",
     "println(img[7.stop].flatStringRepresentation)\n",
@@ -160,6 +161,70 @@
     "img[(-1).step, 1 sl 3 st -1].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
     "println()\n",
     "img[(-1).step, 3.stop st -2].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3D with Scalar Slicing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entire data\n",
+      "IntervalView [(0) -- (1) = 2]: [0, 1] (z=0)\n",
+      "IntervalView [(0) -- (1) = 2]: [2, 3] (z=0)\n",
+      "IntervalView [(0) -- (1) = 2]: [4, 5] (z=0)\n",
+      "IntervalView [(0) -- (1) = 2]: [6, 7] (z=1)\n",
+      "IntervalView [(0) -- (1) = 2]: [8, 9] (z=1)\n",
+      "IntervalView [(0) -- (1) = 2]: [10, 11] (z=1)\n",
+      "IntervalView [(0) -- (1) = 2]: [12, 13] (z=2)\n",
+      "IntervalView [(0) -- (1) = 2]: [14, 15] (z=2)\n",
+      "IntervalView [(0) -- (1) = 2]: [16, 17] (z=2)\n",
+      "IntervalView [(0) -- (1) = 2]: [18, 19] (z=3)\n",
+      "IntervalView [(0) -- (1) = 2]: [20, 21] (z=3)\n",
+      "IntervalView [(0) -- (1) = 2]: [22, 23] (z=3)\n",
+      "\n",
+      "x pinned to 1\n",
+      "IntervalView [(0) -- (2) = 3]: [1, 3, 5]\n",
+      "IntervalView [(0) -- (2) = 3]: [7, 9, 11]\n",
+      "IntervalView [(0) -- (2) = 3]: [13, 15, 17]\n",
+      "IntervalView [(0) -- (2) = 3]: [19, 21, 23]\n",
+      "\n",
+      "y pinned to 0\n",
+      "IntervalView [(0) -- (1) = 2]: [0, 1]\n",
+      "IntervalView [(0) -- (1) = 2]: [6, 7]\n",
+      "IntervalView [(0) -- (1) = 2]: [12, 13]\n",
+      "IntervalView [(0) -- (1) = 2]: [18, 19]\n",
+      "\n",
+      "z pinned to 3, every other y\n",
+      "IntervalView [(0) -- (1) = 2]: [18, 19]\n",
+      "IntervalView [(0) -- (1) = 2]: [22, 23]\n"
+     ]
+    }
+   ],
+   "source": [
+    "val img = imklib.ints(2, 3, 4) { it }\n",
+    "println(\"Entire data\")\n",
+    "for (i in 0 until 4)\n",
+    "    img[_el, i.pos].hyperSlicesList(1).forEach { println(\"${it.flatStringRepresentation} (z=$i)\") }\n",
+    "println()\n",
+    "println(\"x pinned to 1\")\n",
+    "img[1.pos].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "println(\"y pinned to 0\")\n",
+    "img[slice(), 0.pos].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }\n",
+    "println()\n",
+    "println(\"z pinned to 3, every other y\")\n",
+    "img[slice(), 2.step, 3.pos].hyperSlicesList(1).forEach { println(it.flatStringRepresentation) }"
    ]
   }
  ],

--- a/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
+++ b/src/main/kotlin/RandomAccessibleIntervalExtensions.kt
@@ -212,6 +212,15 @@ fun RAI<BooleanType<*>>.any() = iterable.cursor().let { c ->
     false
 }
 
+public fun RAI<out IntegerType<*>>.toIntArray(useFlatIterationOrder: Boolean = true) =
+    IntArray(numElements.toInt()).also { a -> iterable(useFlatIterationOrder).forEachIndexed { i, type -> a[i] = type.getInteger() } }
+public fun RAI<out IntegerType<*>>.toLongArray(flatIterationOrder: Boolean = true) =
+    LongArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getIntegerLong() } }
+public fun RAI<RealType<*>>.toFloatArray(flatIterationOrder: Boolean = true) =
+    FloatArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealFloat() } }
+public fun RAI<RealType<*>>.toDoubleArray(flatIterationOrder: Boolean = true) =
+    DoubleArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealDouble() } }
+
 /**
  * Add slicing access to [RAI] similar to Python. Slices are used to create a sub-interval view that is contained in the
  * original [RAI]. Note that only the dimensions of a [RAI] are considered, but not its min and max. The start and stop
@@ -255,36 +264,39 @@ fun RAI<BooleanType<*>>.any() = iterable.cursor().let { c ->
  * ```
  */
 operator fun <T> RAI<T>.get(vararg slicing: Slicing): RAI<T> {
-    val nonNullSlices = sanitizeSlicing(slicing.toList()).mapIndexed { d, slice -> sanitizeSlice(slice, dimension(d)) }
-    return applyCompleteSlicing(nonNullSlices)
+    val sanitized = sanitizeSlicing(slicing.toList())
+    val positions = sanitized.withIndex().filter { it.value is SanitizedPosition }.map { it.index to it.value as SanitizedPosition }
+    val slices = sanitized.filter { it is SanitizedSlice }.map { it as SanitizedSlice }
+    return applyHyperSlicesForPositions(positions).applyCompleteSlicing(slices)
 }
 
-public fun RAI<out IntegerType<*>>.toIntArray(useFlatIterationOrder: Boolean = true) =
-    IntArray(numElements.toInt()).also { a -> iterable(useFlatIterationOrder).forEachIndexed { i, type -> a[i] = type.getInteger() } }
-public fun RAI<out IntegerType<*>>.toLongArray(flatIterationOrder: Boolean = true) =
-    LongArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getIntegerLong() } }
-public fun RAI<RealType<*>>.toFloatArray(flatIterationOrder: Boolean = true) =
-    FloatArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealFloat() } }
-public fun RAI<RealType<*>>.toDoubleArray(flatIterationOrder: Boolean = true) =
-    DoubleArray(numElements.toInt()).also { a -> iterable(flatIterationOrder).forEachIndexed { i, type -> a[i] = type.getRealDouble() } }
-
-private fun Dimensions.sanitizeSlicing(slicing: List<Slicing>): List<Slice> {
+private fun Dimensions.sanitizeSlicing(slicing: List<Slicing>): List<Sanitized> {
     require(slicing.size <= nDim) { "Number of slices has to be smalller or equal to number of dimensions but got: ${slicing.size} > $nDim. Slicing: ${slicing.toList()}" }
     require(slicing.count { it == _el } <= 1) { "Cannot use more than 1 Ellipsis object. Slicing: ${slicing.toList()}" }
+    require(slicing.all { it::class in compatibleSlicings }) { "Found incompatible slicing: ${slicing.map { it::class }.filter { it !in compatibleSlicings }.toSet()}. Compatible slicings: $compatibleSlicings" }
+
     return when {
         slicing.any { it == _el } -> {
             val index = slicing.indexOf(_el)
             val before = slicing.toList().subList(0, index)
             val after = slicing.toList().subList(index + 1, slicing.size)
-            sanitizeSlicing(before + List(nDim - before.size - after.size) { Slice() } + after)
+            sanitizeSlicing(before + List(nDim - before.size - after.size) { slice() } + after)
         }
         slicing.size < nDim -> sanitizeSlicing(slicing + listOf(_el)) // Using listOf(_el) here only works because the case slicing.any { it == _el } is executed first
-        slicing.all { it is Slice } -> slicing.map { it as Slice }
+        slicing.all { it is Slicing.Slice || it is Slicing.Position } -> slicing.mapIndexed { d, s -> sanitizeSlicing(s, dimension(d)) }
         else -> error("Invalid slicing: $slicing")
     }
 }
 
-private fun sanitizeSlice(slice: Slice, dimension: Long): SanitizedSlice =  when {
+private val compatibleSlicings = setOf(Slicing.Ellipsis::class, Slicing.Slice::class, Slicing.Position::class)
+
+private fun sanitizeSlicing(slicing: Slicing, dimension: Long): Sanitized = when (slicing) {
+    is Slicing.Slice -> sanitizeSlice(slicing, dimension)
+    is Slicing.Position -> SanitizedPosition(slicing.pos)
+    else -> error("Expected ${Slicing.Slice::class} or ${Slicing.Position::class} but got $slicing (${slicing::class})")
+}.also { println("LOL SLIZING $it") }
+
+private fun sanitizeSlice(slice: Slicing.Slice, dimension: Long): SanitizedSlice =  when {
     slice.start === null -> sanitizeSlice(slice.withStart(0L), dimension)
     slice.stop === null -> sanitizeSlice(slice.withStop(dimension), dimension)
     slice.step === null -> sanitizeSlice(slice.withStep(1L), dimension)
@@ -296,21 +308,36 @@ private fun sanitizeSlice(slice: Slice, dimension: Long): SanitizedSlice =  when
     else -> SanitizedSlice(start = slice.start, stop = slice.stop, step = slice.step)
 }
 
-private fun <T> RAI<T>.applyCompleteSlicing(slicing: List<SanitizedSlice>): RAI<T> = when {
-    isZeroMin -> {
-        val restricted = this[slicing.interval].zeroMin as RAI<T>
-        val inverted = (0 until nDim).fold(restricted) { acc, d -> if (slicing[d].step.let { it < 0 } == true) acc.invertAxis(d) else acc }
-        inverted.zeroMin.subsample(*slicing.map { it.step.absoluteValue }.toLongArray())
+private fun <T> RAI<T>.applyHyperSlicesForPositions(slicing: List<Pair<Int, SanitizedPosition>>): RAI<T> {
+    require(nDim >= slicing.size) { "Number of slices inconsistent with number of dimensions: $nDim < ${slicing.size}. slicing=$slicing" }
+    require(slicing.map { it.first }.toSet().size == slicing.size) { "Found duplicates in slicing: $slicing" }
+    require(slicing.none { it.first < 0 || it.first >= nDim }) {"Found slicing dimensions < 0 or > numDimensions: $slicing"}
+    return slicing.sortedByDescending { it.first }.fold(this) { acc, s -> acc.hyperSlice(s.first, s.second.pos) }
+}
+
+private fun <T> RAI<T>.applyCompleteSlicing(slicing: List<SanitizedSlice>): RAI<T> {
+    require(nDim == slicing.size) { "Number of slices inconsistent with number of dimensions: $nDim != ${slicing.size}. slicing=$slicing" }
+    return when {
+        isZeroMin -> {
+            val restricted = this[slicing.interval].zeroMin as RAI<T>
+            val inverted =
+                (0 until nDim).fold(restricted) { acc, d -> if (slicing[d].step.let { it < 0 } == true) acc.invertAxis(d) else acc }
+            inverted.zeroMin.subsample(*slicing.map { it.step.absoluteValue }.toLongArray())
+        }
+        else -> zeroMin.applyCompleteSlicing(slicing)
     }
-    else -> zeroMin.applyCompleteSlicing(slicing)
 
 }
 
-private data class SanitizedSlice(val start: Long, val stop: Long, val step: Long) {
+private interface Sanitized
+
+private data class SanitizedSlice(val start: Long, val stop: Long, val step: Long): Sanitized {
     init {
         require(start <= stop) {"start is larger than stop: $start > $stop"}
         require(step != 0L) {"Invalid step=$step"}
     }
 }
+
+private data class SanitizedPosition(val pos: Long): Sanitized
 
 private val List<SanitizedSlice>.interval get() = (map { it.start } + map { it.stop - 1 }).toLongArray().intervalMinMax

--- a/src/main/kotlin/Slice.kt
+++ b/src/main/kotlin/Slice.kt
@@ -25,44 +25,50 @@
  */
 package net.imglib2.imklib
 
-import net.imglib2.FinalInterval
-import net.imglib2.Interval
-import kotlin.math.max
-import kotlin.math.min
+interface Slicing {
 
-interface Slicing
-
-data class Slice(
+    data class Slice(
         val start: Long? = null,
         val stop: Long? = null,
-        val step: Long? = null): Slicing {
-    init {
-        require(step === null || step != 0L)
+        val step: Long? = null
+    ) : Slicing {
+        init {
+            require(step === null || step != 0L)
+        }
+
+        fun withStart(start: Long?) = Slice(start = start, stop = stop, step = step)
+        fun withStop(stop: Long?) = Slice(start = start, stop = stop, step = step)
+        fun withStep(step: Long?) = Slice(start = start, stop = stop, step = step)
     }
 
-    fun withStart(start: Long?) = Slice(start = start, stop = stop, step = step)
-    fun withStop(stop: Long?) = Slice(start = start, stop = stop, step = step)
-    fun withStep(step: Long?) = Slice(start = start, stop = stop, step = step)
+    class Ellipsis private constructor() : Slicing {
+        companion object {
+            val instance = Ellipsis()
+        }
+    }
+
+    data class Position(val pos: Long): Slicing
 }
 
-class Ellipsis private constructor() : Slicing {
-    companion object {
-        val instance = Ellipsis()
-    }
-}
-val _el = Ellipsis.instance
+fun slice(start: Long? = null, stop: Long? = null, step: Long? = null) = Slicing.Slice(start = start, stop = stop, step = step)
 
 infix fun Int.sl(stop: Int) = toLong() sl stop
 infix fun Int.sl(stop: Long) = toLong() sl stop
 infix fun Long.sl(stop: Int) = sl(stop.toLong())
-infix fun Long.sl(stop: Long) = Slice(start=this, stop=stop)
+infix fun Long.sl(stop: Long) = Slicing.Slice(start=this, stop=stop)
 
 val Int.start get() = toLong().start
 val Int.stop get() = toLong().stop
 val Int.step get() = toLong().step
-val Long.start get() = Slice(start=this)
-val Long.stop get() = Slice(stop=this)
-val Long.step get() = Slice(step=this)
+val Long.start get() = Slicing.Slice(start=this)
+val Long.stop get() = Slicing.Slice(stop=this)
+val Long.step get() = Slicing.Slice(step=this)
 
-infix fun Slice.st(step: Int) = st(step.toLong())
-infix fun Slice.st(step: Long) = Slice(start=start, stop=stop, step=step)
+infix fun Slicing.Slice.st(step: Int) = st(step.toLong())
+infix fun Slicing.Slice.st(step: Long) = Slicing.Slice(start=start, stop=stop, step=step)
+
+
+val _el = Slicing.Ellipsis.instance
+
+val Int.pos get() = toLong().pos
+val Long.pos get() = Slicing.Position(this)

--- a/src/main/kotlin/Slice.kt
+++ b/src/main/kotlin/Slice.kt
@@ -33,7 +33,7 @@ interface Slicing {
         val step: Long? = null
     ) : Slicing {
         init {
-            require(step === null || step != 0L)
+            require(step === null || step != 0L) { "Invalid step: $step" }
         }
 
         fun withStart(start: Long?) = Slice(start = start, stop = stop, step = step)
@@ -42,6 +42,7 @@ interface Slicing {
     }
 
     class Ellipsis private constructor() : Slicing {
+        override fun toString() = this::class.simpleName ?: "Ellipsis"
         companion object {
             val instance = Ellipsis()
         }

--- a/src/test/kotlin/TestSlicing.kt
+++ b/src/test/kotlin/TestSlicing.kt
@@ -111,7 +111,7 @@ class TestSlicing {
 
     @Test fun `slice 3D`() {
         val data = imklib.ints(2, 3, 4) { it }
-        val sliced1 = data[Slice(), _el, 3 sl 4]
+        val sliced1 = data[slice(), _el, 3 sl 4]
         val sliced2 = data[_el, 3 sl 4]
         val expected = IntArray(6) { it + 18 }
         Assert.assertArrayEquals(expected, sliced1.toIntArray())
@@ -128,11 +128,43 @@ class TestSlicing {
     @Test fun `test 3D slicing empty`() {
         val data = imklib.ints(2, 3, 4) { it }
         val sliced1 = data[0.stop]
-        val sliced2 = data[Slice(), 0.stop]
+        val sliced2 = data[slice(), 0.stop]
         val sliced3 = data[_el, 0.stop]
         Assert.assertTrue(sliced1.isEmpty)
         Assert.assertTrue(sliced2.isEmpty)
         Assert.assertTrue(sliced3.isEmpty)
+    }
+
+    @Test fun `test 3D slicing with pos aka hyperSlice`() {
+        val data = imklib.ints(2, 3, 4) { it }
+        val sliced1 = data[0.pos]
+        val sliced2 = data[slice(), 1.pos]
+        val sliced3 = data[_el, 2.pos]
+        Assert.assertEquals(2, sliced1.numDimensions())
+        Assert.assertEquals(2, sliced2.numDimensions())
+        Assert.assertEquals(2, sliced3.numDimensions())
+        Assert.assertArrayEquals(longArrayOf(3, 4), sliced1.dimensionsAsLongArray())
+        Assert.assertArrayEquals(longArrayOf(2, 4), sliced2.dimensionsAsLongArray())
+        Assert.assertArrayEquals(longArrayOf(2, 3), sliced3.dimensionsAsLongArray())
+        Assert.assertArrayEquals(IntArray(12) { it * 2 }, sliced1.toIntArray())
+        Assert.assertArrayEquals(intArrayOf(2, 3, 8, 9, 14, 15 ,20, 21), sliced2.toIntArray())
+        Assert.assertArrayEquals(IntArray(6) { it + 12 }, sliced3.toIntArray())
+    }
+
+    @Test fun `test 3D slicing with pos and slice`() {
+        val data = imklib.ints(2, 3, 4) { it }
+        val sliced1 = data[0.pos, 2.step]
+        val sliced2 = data[_el, 1.pos, 3.step]
+        val sliced3 = data[1 sl 2, _el, 2.pos]
+        Assert.assertEquals(2, sliced1.numDimensions())
+        Assert.assertEquals(2, sliced2.numDimensions())
+        Assert.assertEquals(2, sliced3.numDimensions())
+        Assert.assertArrayEquals(longArrayOf(2, 4), sliced1.dimensionsAsLongArray())
+        Assert.assertArrayEquals(longArrayOf(2, 2), sliced2.dimensionsAsLongArray())
+        Assert.assertArrayEquals(longArrayOf(1, 3), sliced3.dimensionsAsLongArray())
+        Assert.assertArrayEquals(intArrayOf(0, 4, 6, 10, 12, 16, 18, 22), sliced1.toIntArray())
+        Assert.assertArrayEquals(intArrayOf(2, 3, 20, 21), sliced2.toIntArray())
+        Assert.assertArrayEquals(IntArray(3) { 13 + 2 * it }, sliced3.toIntArray())
     }
 
 }

--- a/src/test/kotlin/TestSlicing.kt
+++ b/src/test/kotlin/TestSlicing.kt
@@ -25,6 +25,7 @@
  */
 package net.imglib2.imklib
 
+import io.minio.errors.InvalidArgumentException
 import org.junit.Assert
 import kotlin.test.Test
 import org.junit.jupiter.api.TestInstance
@@ -34,9 +35,12 @@ class TestSlicing {
 
     @Test fun `test 1D slicing same interval`() {
         val data = imklib.ints(10) { it }
-        val sliced = data[_el]
-        Assert.assertArrayEquals(data.dimensionsAsLongArray(), sliced.dimensionsAsLongArray())
-        Assert.assertTrue((sliced eq data).all())
+        val sliced1 = data[_el]
+        val sliced2 = data[0 sl 10 st 1]
+        Assert.assertArrayEquals(data.dimensionsAsLongArray(), sliced1.dimensionsAsLongArray())
+        Assert.assertArrayEquals(data.dimensionsAsLongArray(), sliced2.dimensionsAsLongArray())
+        Assert.assertTrue((sliced1 eq data).all())
+        Assert.assertTrue((sliced2 eq data).all())
     }
 
     @Test fun `test 1D slicing invert axis`() {
@@ -61,20 +65,16 @@ class TestSlicing {
         val data = imklib.ints(10) { it }
         val sliced1 = data[3.start]
         val sliced2 = data[(-7).start]
-        val sliced3 = data[(-17).start]
         Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced1.toIntArray())
         Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced2.toIntArray())
-        Assert.assertArrayEquals(IntArray(7) { it + 3 }, sliced3.toIntArray())
     }
 
     @Test fun `test 1D slicing stop at 7`() {
         val data = imklib.ints(10) { it }
         val sliced1 = data[7.stop]
         val sliced2 = data[(-3).stop]
-        val sliced3 = data[(-13).stop]
         Assert.assertArrayEquals(IntArray(7) { it }, sliced1.toIntArray())
         Assert.assertArrayEquals(IntArray(7) { it }, sliced2.toIntArray())
-        Assert.assertArrayEquals(IntArray(7) { it }, sliced3.toIntArray())
     }
 
     @Test fun `test 1D slicing start=3 stop=7 step=3`() {
@@ -153,9 +153,9 @@ class TestSlicing {
 
     @Test fun `test 3D slicing with pos and slice`() {
         val data = imklib.ints(2, 3, 4) { it }
-        val sliced1 = data[0.pos, 2.step]
-        val sliced2 = data[_el, 1.pos, 3.step]
-        val sliced3 = data[1 sl 2, _el, 2.pos]
+        val sliced1 = data[(-2).pos, 2.step]
+        val sliced2 = data[_el, (-2).pos, 3.step]
+        val sliced3 = data[1 sl 2, _el, (-2).pos]
         Assert.assertEquals(2, sliced1.numDimensions())
         Assert.assertEquals(2, sliced2.numDimensions())
         Assert.assertEquals(2, sliced3.numDimensions())
@@ -165,6 +165,31 @@ class TestSlicing {
         Assert.assertArrayEquals(intArrayOf(0, 4, 6, 10, 12, 16, 18, 22), sliced1.toIntArray())
         Assert.assertArrayEquals(intArrayOf(2, 3, 20, 21), sliced2.toIntArray())
         Assert.assertArrayEquals(IntArray(3) { 13 + 2 * it }, sliced3.toIntArray())
+    }
+
+    @Test fun `test errors`() {
+        data class FailSlice(val nothing: Unit = Unit): Slicing
+        val data = imklib.ints(3, 4) { it }
+        val slicings = listOf(
+            arrayOf(FailSlice()),
+            arrayOf(_el, _el),
+            arrayOf(1.pos, 2 sl 3, 4.step),
+            arrayOf((-4).pos),
+            arrayOf(4.pos),
+            arrayOf(-4 sl 3),
+            arrayOf(0 sl -4),
+            arrayOf(4 sl 3),
+            arrayOf(3 sl 4)
+        )
+        for (slicing in slicings) {
+            try {
+                data.get(*slicing)
+                Assert.fail("Expected ${IllegalArgumentException::class.simpleName} for invalid slicing ${slicing.toList()}.")
+            } catch (e: IllegalArgumentException) {
+                // expected exception, uncomment for logging:
+                // println(e.message)
+            }
+        }
     }
 
 }


### PR DESCRIPTION
This PR improves slicing for `RandomAccessibleInterval`. Instead of just allowing slices with `start`, `stop`, `step`, scalar indices can be used now. To avoid conflicts with voxel access with `varag Long` and `vararg Int`, a new class `Position : Slice` and convenience functions to generate instances from `Int` and `Long` is added.

Also: Improve test cases and argument validation.